### PR TITLE
Fiks lintr-fil

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
-linters: with_defaults(
+linters: linters_with_defaults(
   object_name_linter(c("camelCase", "snake_case")),
   cyclocomp_linter(complexity_limit = 25),
   line_length_linter(80))


### PR DESCRIPTION
Function with_defaults was deprecated in lintr version 3.0.0. Use linters_with_defaults or modify_defaults instead.